### PR TITLE
Codes can be of type int instead of string

### DIFF
--- a/src/Service/SyliusAkeneoLocaleCodeProvider.php
+++ b/src/Service/SyliusAkeneoLocaleCodeProvider.php
@@ -48,11 +48,11 @@ final class SyliusAkeneoLocaleCodeProvider
      */
     public function isLocaleDataTranslation(AttributeInterface $attribute, $data, string $locale): bool
     {
-        if (isset($attribute->getConfiguration()['choices'][$data]) && array_key_exists($locale, $attribute->getConfiguration()['choices'][$data])) {
-            return true;
+        if (is_array($data)) {
+            return $data['locale'] === $locale;
         }
 
-        if (is_array($data) && $data['locale'] === $locale) {
+        if (isset($attribute->getConfiguration()['choices'][$data]) && array_key_exists($locale, $attribute->getConfiguration()['choices'][$data])) {
             return true;
         }
 

--- a/src/Task/Attribute/CreateUpdateEntityTask.php
+++ b/src/Task/Attribute/CreateUpdateEntityTask.php
@@ -155,7 +155,7 @@ final class CreateUpdateEntityTask implements AkeneoTaskInterface
 
     private function getOrCreateEntity(array $resource, AttributeTypeMatcherInterface $attributeType): AttributeInterface
     {
-        $code = $this->akeneoAttributeToSyliusAttributeTransformer->transform($resource['code']);
+        $code = $this->akeneoAttributeToSyliusAttributeTransformer->transform((string) $resource['code']);
         /** @var AttributeInterface $attribute */
         $attribute = $this->productAttributeRepository->findOneBy(['code' => $code]);
 

--- a/src/Task/Attribute/DeleteEntityTask.php
+++ b/src/Task/Attribute/DeleteEntityTask.php
@@ -75,7 +75,7 @@ final class DeleteEntityTask implements AkeneoTaskInterface
             $this->entityManager->beginTransaction();
 
             foreach ($payload->getResources() as $resource) {
-                $code = $this->akeneoAttributeToSyliusAttributeTransformer->transform($resource['code']);
+                $code = $this->akeneoAttributeToSyliusAttributeTransformer->transform((string) $resource['code']);
                 $attributeCodes[] = $code;
             }
 

--- a/src/Task/Attribute/LocaleAttributeTranslationTask.php
+++ b/src/Task/Attribute/LocaleAttributeTranslationTask.php
@@ -13,7 +13,6 @@ use Synolia\SyliusAkeneoPlugin\Payload\PipelinePayloadInterface;
 use Synolia\SyliusAkeneoPlugin\Provider\AkeneoAttributeDataProvider;
 use Synolia\SyliusAkeneoPlugin\Service\SyliusAkeneoLocaleCodeProvider;
 use Synolia\SyliusAkeneoPlugin\Task\AkeneoTaskInterface;
-use Synolia\SyliusAkeneoPlugin\Task\AttributeOption\CreateUpdateDeleteTask;
 
 final class LocaleAttributeTranslationTask implements AkeneoTaskInterface
 {
@@ -101,56 +100,10 @@ final class LocaleAttributeTranslationTask implements AkeneoTaskInterface
             $attributeValue = $this->productAttributeValueFactory->createNew();
         }
 
-        $localeValues = $this->getLocaleTranslations($attribute, $translations, $locale);
-        if ($localeValues === null) {
-            return;
-        }
-
         $attributeValue->setLocaleCode($locale);
         $attributeValue->setAttribute($attribute);
-        $attributeValueValue = $this->akeneoAttributeDataProvider->getData($attributeCode, $localeValues, $locale, $scope);
+        $attributeValueValue = $this->akeneoAttributeDataProvider->getData($attributeCode, $translations, $locale, $scope);
         $attributeValue->setValue($attributeValueValue);
         $payload->getProduct()->addAttribute($attributeValue);
-    }
-
-    private function getLocaleTranslations(AttributeInterface $attribute, array $translations, string $locale): ?array
-    {
-        $localeTranslations = [];
-        if (count($translations) > 1) {
-            foreach ($translations as $translation) {
-                if ($this->syliusAkeneoLocaleCodeProvider->isLocaleDataTranslation($attribute, $translation, $locale) === false) {
-                    continue;
-                }
-                $localeTranslations[] = $translation;
-            }
-
-            return $localeTranslations;
-        }
-
-        if ($attribute->getConfiguration() === []) {
-            return $translations;
-        }
-
-        if (!is_array($translations[0]['data'])) {
-            $isLocaleDataValues = $this->syliusAkeneoLocaleCodeProvider->isLocaleDataTranslation($attribute, CreateUpdateDeleteTask::AKENEO_PREFIX . $translations[0]['data'], $locale);
-            if ($isLocaleDataValues === false) {
-                return null;
-            }
-
-            return $translations;
-        }
-
-        $datas = [];
-        foreach ($translations[0]['data'] as $data) {
-            $data = CreateUpdateDeleteTask::AKENEO_PREFIX . $data;
-            if ($this->syliusAkeneoLocaleCodeProvider->isLocaleDataTranslation($attribute, $data, $locale) === false) {
-                continue;
-            }
-            $datas[] = $data;
-        }
-
-        $translations[0]['data'] = $datas;
-
-        return $translations;
     }
 }

--- a/src/Task/AttributeOption/CreateUpdateDeleteTask.php
+++ b/src/Task/AttributeOption/CreateUpdateDeleteTask.php
@@ -70,7 +70,7 @@ final class CreateUpdateDeleteTask implements AkeneoTaskInterface
             $this->entityManager->beginTransaction();
 
             foreach ($payload->getResources() as $attributeCode => $optionResources) {
-                $this->processByAttribute($attributeCode, $optionResources['resources'], $optionResources['isMultiple']);
+                $this->processByAttribute((string) $attributeCode, $optionResources['resources'], $optionResources['isMultiple']);
             }
 
             $this->entityManager->flush();

--- a/src/Task/Product/AddAttributesToProductTask.php
+++ b/src/Task/Product/AddAttributesToProductTask.php
@@ -52,7 +52,7 @@ final class AddAttributesToProductTask implements AkeneoTaskInterface
         }
 
         foreach ($payload->getResource()['values'] as $attributeCode => $translations) {
-            $transformedAttributeCode = $this->akeneoAttributeToSyliusAttributeTransformer->transform($attributeCode);
+            $transformedAttributeCode = $this->akeneoAttributeToSyliusAttributeTransformer->transform((string) $attributeCode);
 
             /** @var AttributeInterface $attribute */
             $attribute = $this->productAttributeRepository->findOneBy(['code' => $transformedAttributeCode]);
@@ -60,11 +60,11 @@ final class AddAttributesToProductTask implements AkeneoTaskInterface
                 continue;
             }
 
-            if (!$this->attributeValueValueBuilder->hasSupportedBuilder($attributeCode)) {
+            if (!$this->attributeValueValueBuilder->hasSupportedBuilder((string) $attributeCode)) {
                 continue;
             }
 
-            $this->setAttributeTranslations($payload, $translations, $attribute, $attributeCode, $payload->getScope());
+            $this->setAttributeTranslations($payload, $translations, $attribute, (string) $attributeCode, $payload->getScope());
         }
 
         return $payload;

--- a/src/Task/Product/CreateSimpleProductEntitiesTask.php
+++ b/src/Task/Product/CreateSimpleProductEntitiesTask.php
@@ -225,12 +225,16 @@ final class CreateSimpleProductEntitiesTask extends AbstractCreateProductEntitie
         $missingNameTranslationCount = 0;
         $familyResource = $this->payload->getAkeneoPimClient()->getFamilyApi()->get($familyCode);
         foreach ($this->syliusAkeneoLocaleCodeProvider->getUsedLocalesOnBothPlatforms() as $usedLocalesOnBothPlatform) {
-            $productName = $this->akeneoAttributeDataProvider->getData(
-                $familyResource['attribute_as_label'],
-                $resource['values'][$familyResource['attribute_as_label']],
-                $usedLocalesOnBothPlatform,
-                $this->scope
-            );
+            $productName = null;
+
+            if (isset($resource['values'][$familyResource['attribute_as_label']])) {
+                $productName = $this->akeneoAttributeDataProvider->getData(
+                    $familyResource['attribute_as_label'],
+                    $resource['values'][$familyResource['attribute_as_label']],
+                    $usedLocalesOnBothPlatform,
+                    $this->scope
+                );
+            }
 
             if (null === $productName) {
                 $productName = \sprintf('[%s]', $product->getCode());

--- a/src/Task/ProductModel/AddOrUpdateProductModelTask.php
+++ b/src/Task/ProductModel/AddOrUpdateProductModelTask.php
@@ -338,12 +338,16 @@ final class AddOrUpdateProductModelTask implements AkeneoTaskInterface
         $missingNameTranslationCount = 0;
         $familyResource = $this->payload->getAkeneoPimClient()->getFamilyApi()->get($familyCode);
         foreach ($this->syliusAkeneoLocaleCodeProvider->getUsedLocalesOnBothPlatforms() as $usedLocalesOnBothPlatform) {
-            $productName = $this->akeneoAttributeDataProvider->getData(
-                $familyResource['attribute_as_label'],
-                $resource['values'][$familyResource['attribute_as_label']],
-                $usedLocalesOnBothPlatform,
-                $this->scope
-            );
+            $productName = null;
+
+            if (isset($resource['values'][$familyResource['attribute_as_label']])) {
+                $productName = $this->akeneoAttributeDataProvider->getData(
+                    $familyResource['attribute_as_label'],
+                    $resource['values'][$familyResource['attribute_as_label']],
+                    $usedLocalesOnBothPlatform,
+                    $this->scope
+                );
+            }
 
             if (null === $productName) {
                 $productName = \sprintf('[%s]', $product->getCode());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no
| Fixed issue | 

If codes (for attributes for example) are int, imports throw error because of typeint.