### PR TITLE
Introduce ProductFilterInterface to allow extending

### DIFF
--- a/src/Filter/ProductFilter.php
+++ b/src/Filter/ProductFilter.php
@@ -13,7 +13,7 @@ use Synolia\SyliusAkeneoPlugin\Form\Type\ProductFilterRuleAdvancedType;
 use Synolia\SyliusAkeneoPlugin\Form\Type\ProductFilterRuleSimpleType;
 use Synolia\SyliusAkeneoPlugin\Service\SyliusAkeneoLocaleCodeProvider;
 
-final class ProductFilter
+final class ProductFilter implements ProductFilterInterface
 {
     private const AT_LEAST_COMPLETE = 'AT LEAST COMPLETE';
 

--- a/src/Filter/ProductFilterInterface.php
+++ b/src/Filter/ProductFilterInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Synolia\SyliusAkeneoPlugin\Filter;
+
+interface ProductFilterInterface
+{
+    public function getProductModelFilters(): array;
+
+    public function getProductFilters(): array;
+}

--- a/src/Task/Product/RetrieveProductsTask.php
+++ b/src/Task/Product/RetrieveProductsTask.php
@@ -8,7 +8,7 @@ use Akeneo\Pim\ApiClient\Pagination\Page;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
-use Synolia\SyliusAkeneoPlugin\Filter\ProductFilter;
+use Synolia\SyliusAkeneoPlugin\Filter\ProductFilterInterface;
 use Synolia\SyliusAkeneoPlugin\Logger\Messages;
 use Synolia\SyliusAkeneoPlugin\Payload\PipelinePayloadInterface;
 use Synolia\SyliusAkeneoPlugin\Payload\Product\ProductPayload;
@@ -23,7 +23,7 @@ final class RetrieveProductsTask implements AkeneoTaskInterface
     /** @var ConfigurationProvider */
     private $configurationProvider;
 
-    /** @var \Synolia\SyliusAkeneoPlugin\Filter\ProductFilter */
+    /** @var ProductFilterInterface */
     private $productFilter;
 
     /** @var \Doctrine\ORM\EntityManagerInterface */
@@ -32,7 +32,7 @@ final class RetrieveProductsTask implements AkeneoTaskInterface
     public function __construct(
         LoggerInterface $akeneoLogger,
         ConfigurationProvider $configurationProvider,
-        ProductFilter $productFilter,
+        ProductFilterInterface $productFilter,
         EntityManagerInterface $entityManager
     ) {
         $this->logger = $akeneoLogger;

--- a/src/Task/ProductModel/RetrieveProductModelsTask.php
+++ b/src/Task/ProductModel/RetrieveProductModelsTask.php
@@ -6,7 +6,7 @@ namespace Synolia\SyliusAkeneoPlugin\Task\ProductModel;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
-use Synolia\SyliusAkeneoPlugin\Filter\ProductFilter;
+use Synolia\SyliusAkeneoPlugin\Filter\ProductFilterInterface;
 use Synolia\SyliusAkeneoPlugin\Logger\Messages;
 use Synolia\SyliusAkeneoPlugin\Payload\PipelinePayloadInterface;
 use Synolia\SyliusAkeneoPlugin\Payload\ProductModel\ProductModelPayload;
@@ -16,7 +16,7 @@ use Synolia\SyliusAkeneoPlugin\Task\AkeneoTaskInterface;
 
 final class RetrieveProductModelsTask implements AkeneoTaskInterface
 {
-    /** @var ProductFilter */
+    /** @var ProductFilterInterface */
     private $productFilter;
 
     /** @var LoggerInterface */
@@ -32,7 +32,7 @@ final class RetrieveProductModelsTask implements AkeneoTaskInterface
     private $entityManager;
 
     public function __construct(
-        ProductFilter $productFilter,
+        ProductFilterInterface $productFilter,
         ConfigurationProvider $configurationProvider,
         LoggerInterface $logger,
         AkeneoTaskProvider $taskProvider,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?   | no
| Fixed issue | #... <!-- #-prefixed issue number(s), if any -->

This is to allow using the `\Synolia\SyliusAkeneoPlugin\Task\Product\RetrieveProductsTask` without using the specific `\Synolia\SyliusAkeneoPlugin\Filter\ProductFilter`.

What do you think ?