### PR TITLE
Introduce ProductFilterInterface::getChannel to allow further extension

### DIFF
--- a/src/Filter/ProductFilter.php
+++ b/src/Filter/ProductFilter.php
@@ -43,7 +43,7 @@ final class ProductFilter implements ProductFilterInterface
         $this->syliusAkeneoLocaleCodeProvider = $syliusAkeneoLocaleCodeProvider;
     }
 
-    public function getProductModelFilters(): array
+    public function getModelQueryParameters(): array
     {
         /** @var ProductFiltersRules $productFilterRules */
         $productFilterRules = $this->productFiltersRulesRepository->findOneBy([]);
@@ -75,7 +75,7 @@ final class ProductFilter implements ProductFilterInterface
         return $queryParameters;
     }
 
-    public function getProductFilters(): array
+    public function getQueryParameters(): array
     {
         /** @var ProductFiltersRules $productFilterRules */
         $productFilterRules = $this->productFiltersRulesRepository->findOneBy([]);
@@ -106,6 +106,17 @@ final class ProductFilter implements ProductFilterInterface
         }
 
         return $queryParameters;
+    }
+
+    public function getChannel(): ?string
+    {
+        /** @var ProductFiltersRules $productFilterRules */
+        $productFilterRules = $this->productFiltersRulesRepository->findOneBy([]);
+        if (!$productFilterRules instanceof ProductFiltersRules) {
+            return null;
+        }
+
+        return $productFilterRules->getChannel();
     }
 
     private function getStatus(ProductFiltersRules $productFilterRules, SearchBuilder $queryParameters): SearchBuilder

--- a/src/Filter/ProductFilterInterface.php
+++ b/src/Filter/ProductFilterInterface.php
@@ -6,7 +6,9 @@ namespace Synolia\SyliusAkeneoPlugin\Filter;
 
 interface ProductFilterInterface
 {
-    public function getProductModelFilters(): array;
+    public function getModelQueryParameters(): array;
 
-    public function getProductFilters(): array;
+    public function getQueryParameters(): array;
+
+    public function getChannel(): ?string;
 }

--- a/src/Task/Product/RetrieveProductsTask.php
+++ b/src/Task/Product/RetrieveProductsTask.php
@@ -53,7 +53,7 @@ final class RetrieveProductsTask implements AkeneoTaskInterface
         $this->logger->debug(self::class);
         $this->logger->notice(Messages::retrieveFromAPI($payload->getType()));
 
-        $queryParameters = $this->productFilter->getProductFilters();
+        $queryParameters = $this->productFilter->getQueryParameters();
         $queryParameters['pagination_type'] = 'search_after';
 
         /** @var \Akeneo\Pim\ApiClient\Pagination\PageInterface|null $resources */

--- a/src/Task/ProductModel/RetrieveProductModelsTask.php
+++ b/src/Task/ProductModel/RetrieveProductModelsTask.php
@@ -50,7 +50,7 @@ final class RetrieveProductModelsTask implements AkeneoTaskInterface
      */
     public function __invoke(PipelinePayloadInterface $payload): PipelinePayloadInterface
     {
-        $queryParameters = $this->productFilter->getProductModelFilters();
+        $queryParameters = $this->productFilter->getModelQueryParameters();
 
         $this->logger->debug(self::class);
         $this->logger->notice(Messages::retrieveFromAPI($payload->getType()));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?   | no
| Fixed issue | N.A.

Following the introduction of `\Synolia\SyliusAkeneoPlugin\Filter\ProductFilterInterface`, I replaced the dependency between the `ProductFiltersRules` repository and  the two `CreateSimpleProductEntitiesTask` and `CreateConfigurableProductEntitiesTask` by a dependency on `ProductFilterInterface`.
In my case, it allows to reuse those tasks without having to fake the repository.

NB : I was tempted to move the initialization of `$this->scope` in the constructor of the tasks.. let me know if you find it a good idea !