### PR TITLE
Remove call db in construct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ sylius-standard:
 install-plugin:
 	${COMPOSER} config repositories.plugin '{"type": "path", "url": "../../"}'
 	${COMPOSER} config extra.symfony.allow-contrib true
+	${COMPOSER} config allow-plugins true
 	${COMPOSER} config minimum-stability "dev"
 	${COMPOSER} config prefer-stable true
 	${COMPOSER} req "${PLUGIN_NAME}:*" --prefer-source --no-scripts

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ sylius-standard:
 install-plugin:
 	${COMPOSER} config repositories.plugin '{"type": "path", "url": "../../"}'
 	${COMPOSER} config extra.symfony.allow-contrib true
-	${COMPOSER} config allow-plugins true
 	${COMPOSER} config minimum-stability "dev"
 	${COMPOSER} config prefer-stable true
 	${COMPOSER} req "${PLUGIN_NAME}:*" --prefer-source --no-scripts

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,13 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "symfony/thanks": true,
+            "phpro/grumphp": true,
+            "phpstan/extension-installer": true
+        }
     },
     "extra": {
         "symfony": {

--- a/ruleset/phpstan.neon
+++ b/ruleset/phpstan.neon
@@ -1,6 +1,5 @@
 parameters:
     level: max
-    reportUnmatchedIgnoredErrors: false
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
     bootstrapFiles:

--- a/src/Checker/Product/IsProductProcessableChecker.php
+++ b/src/Checker/Product/IsProductProcessableChecker.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Synolia\SyliusAkeneoPlugin\Checker\Product;
 
-use Akeneo\PimEnterprise\ApiClient\AkeneoPimEnterpriseClientInterface;
 use Psr\Log\LoggerInterface;
 use Synolia\SyliusAkeneoPlugin\Client\ClientFactoryInterface;
 
@@ -12,7 +11,7 @@ final class IsProductProcessableChecker implements IsProductProcessableCheckerIn
 {
     private const ONE_VARIATION_AXIS = 1;
 
-    private AkeneoPimEnterpriseClientInterface $client;
+    private ClientFactoryInterface $clientFactory;
 
     private LoggerInterface $logger;
 
@@ -20,7 +19,7 @@ final class IsProductProcessableChecker implements IsProductProcessableCheckerIn
 
     public function __construct(ClientFactoryInterface $clientFactory, LoggerInterface $logger)
     {
-        $this->client = $clientFactory->createFromApiCredentials();
+        $this->clientFactory = $clientFactory;
         $this->logger = $logger;
         $this->familyVariants = [];
     }
@@ -58,10 +57,13 @@ final class IsProductProcessableChecker implements IsProductProcessableCheckerIn
             return $this->familyVariants[$family][$familyVariant];
         }
 
-        $familyVariantPayload = $this->client->getFamilyVariantApi()->get(
-            $family,
-            $familyVariant
-        );
+        $familyVariantPayload = $this->clientFactory
+            ->createFromApiCredentials()
+            ->getFamilyVariantApi()
+            ->get(
+                $family,
+                $familyVariant
+            );
 
         $this->familyVariants[$family][$familyVariant] = $familyVariantPayload;
 

--- a/src/Client/ClientFactory.php
+++ b/src/Client/ClientFactory.php
@@ -11,8 +11,9 @@ use Synolia\SyliusAkeneoPlugin\Entity\ApiConfiguration;
 
 final class ClientFactory implements ClientFactoryInterface
 {
-    /** @var \Sylius\Component\Resource\Repository\RepositoryInterface */
-    private $apiConfigurationRepository;
+    private RepositoryInterface $apiConfigurationRepository;
+
+    private ?AkeneoPimEnterpriseClientInterface $akeneoClient = null;
 
     public function __construct(RepositoryInterface $apiConfigurationRepository)
     {
@@ -21,6 +22,10 @@ final class ClientFactory implements ClientFactoryInterface
 
     public function createFromApiCredentials(): AkeneoPimEnterpriseClientInterface
     {
+        if (null !== $this->akeneoClient) {
+            return $this->akeneoClient;
+        }
+
         /** @var ApiConfiguration|null $apiConfiguration */
         $apiConfiguration = $this->apiConfigurationRepository->findOneBy([], ['id' => 'DESC']);
 
@@ -28,7 +33,9 @@ final class ClientFactory implements ClientFactoryInterface
             throw new \Exception('The API is not configured in the admin section.');
         }
 
-        return $this->authenticateByPassword($apiConfiguration);
+        $this->akeneoClient = $this->authenticateByPassword($apiConfiguration);
+
+        return $this->akeneoClient;
     }
 
     public function authenticateByPassword(ApiConfiguration $apiConfiguration): AkeneoPimEnterpriseClientInterface

--- a/src/Form/Type/AttributeCodeChoiceType.php
+++ b/src/Form/Type/AttributeCodeChoiceType.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Synolia\SyliusAkeneoPlugin\Form\Type;
 
 use Akeneo\Pim\ApiClient\Pagination\ResourceCursorInterface;
-use Akeneo\PimEnterprise\ApiClient\AkeneoPimEnterpriseClientInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -16,7 +15,7 @@ use Synolia\SyliusAkeneoPlugin\Task\Attribute\RetrieveAttributesTask;
 
 final class AttributeCodeChoiceType extends AbstractType
 {
-    private AkeneoPimEnterpriseClientInterface $akeneoPimClient;
+    private ClientFactoryInterface $clientFactory;
 
     private LocaleContextInterface $localeContext;
 
@@ -27,14 +26,14 @@ final class AttributeCodeChoiceType extends AbstractType
         LocaleContextInterface $localeContext,
         RetrieveAttributesTask $retrieveAttributesTask
     ) {
-        $this->akeneoPimClient = $clientFactory->createFromApiCredentials();
+        $this->clientFactory = $clientFactory;
         $this->localeContext = $localeContext;
         $this->retrieveAttributesTask = $retrieveAttributesTask;
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $payload = new AttributePayload($this->akeneoPimClient);
+        $payload = new AttributePayload($this->clientFactory->createFromApiCredentials());
         /** @var AttributePayload $attributePayload */
         $attributePayload = $this->retrieveAttributesTask->__invoke($payload);
 
@@ -54,7 +53,7 @@ final class AttributeCodeChoiceType extends AbstractType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/src/Form/Type/ChannelChoiceType.php
+++ b/src/Form/Type/ChannelChoiceType.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Synolia\SyliusAkeneoPlugin\Form\Type;
 
-use Akeneo\Pim\ApiClient\Api\ChannelApiInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -12,16 +11,16 @@ use Synolia\SyliusAkeneoPlugin\Client\ClientFactoryInterface;
 
 final class ChannelChoiceType extends AbstractType
 {
-    private ChannelApiInterface $channelApi;
+    private ClientFactoryInterface $clientFactory;
 
     public function __construct(ClientFactoryInterface $clientFactory)
     {
-        $this->channelApi = $clientFactory->createFromApiCredentials()->getChannelApi();
+        $this->clientFactory = $clientFactory;
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $channelApi = $this->channelApi->all();
+        $channelApi = $this->clientFactory->createFromApiCredentials()->getChannelApi()->all();
         $channel = [];
         foreach ($channelApi as $item) {
             $channel[$item['code']] = $item['code'];

--- a/src/Form/Type/FamiliesChoiceType.php
+++ b/src/Form/Type/FamiliesChoiceType.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Synolia\SyliusAkeneoPlugin\Form\Type;
 
-use Akeneo\PimEnterprise\ApiClient\AkeneoPimEnterpriseClientInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -12,16 +11,16 @@ use Synolia\SyliusAkeneoPlugin\Client\ClientFactoryInterface;
 
 final class FamiliesChoiceType extends AbstractType
 {
-    private AkeneoPimEnterpriseClientInterface $akeneoPimClient;
+    private ClientFactoryInterface $clientFactory;
 
     public function __construct(ClientFactoryInterface $clientFactory)
     {
-        $this->akeneoPimClient = $clientFactory->createFromApiCredentials();
+        $this->clientFactory = $clientFactory;
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $familiesResult = $this->akeneoPimClient->getFamilyApi()->all();
+        $familiesResult = $this->clientFactory->createFromApiCredentials()->getFamilyApi()->all();
         if (empty($familiesResult)) {
             return;
         }

--- a/src/Processor/ProductAttribute/ProductAttributeChoiceProcessor.php
+++ b/src/Processor/ProductAttribute/ProductAttributeChoiceProcessor.php
@@ -18,7 +18,7 @@ use Synolia\SyliusAkeneoPlugin\TypeMatcher\Attribute\SelectAttributeTypeMatcher;
 
 final class ProductAttributeChoiceProcessor implements ProductAttributeChoiceProcessorInterface
 {
-    private \Akeneo\PimEnterprise\ApiClient\AkeneoPimEnterpriseClientInterface $client;
+    private ClientFactoryInterface $clientFactory;
 
     private AttributeTypeMatcher $attributeTypeMatcher;
 
@@ -41,7 +41,7 @@ final class ProductAttributeChoiceProcessor implements ProductAttributeChoicePro
         AttributeOptionValueDataTransformerInterface $attributeOptionValueDataTransformer,
         EntityManagerInterface $entityManager
     ) {
-        $this->client = $clientFactory->createFromApiCredentials();
+        $this->clientFactory = $clientFactory;
         $this->attributeTypeMatcher = $attributeTypeMatcher;
         $this->logger = $akeneoLogger;
         $this->syliusAkeneoLocaleCodeProvider = $syliusAkeneoLocaleCodeProvider;
@@ -66,7 +66,7 @@ final class ProductAttributeChoiceProcessor implements ProductAttributeChoicePro
 
             $this->setAttributeChoices(
                 $attribute,
-                $this->client->getAttributeOptionApi()->all(
+                $this->clientFactory->createFromApiCredentials()->getAttributeOptionApi()->all(
                     $resource['code'],
                     $this->configurationProvider->getConfiguration()->getPaginationSize()
                 ),
@@ -123,6 +123,7 @@ final class ProductAttributeChoiceProcessor implements ProductAttributeChoicePro
             return [];
         }
 
+        $localeUnused = [];
         foreach ($localeDiff as $locale) {
             $localeUnused[$locale] = ' ';
         }

--- a/tests/PHPUnit/Task/Product/AbstractTaskTest.php
+++ b/tests/PHPUnit/Task/Product/AbstractTaskTest.php
@@ -141,15 +141,21 @@ abstract class AbstractTaskTest extends ApiTestCase
 
     protected function createConfiguration(): void
     {
-        $apiConfiguration = new ApiConfiguration();
-        $apiConfiguration->setBaseUrl('');
-        $apiConfiguration->setApiClientId('');
-        $apiConfiguration->setApiClientSecret('');
+        $apiConfiguration = $this->manager->getRepository(ApiConfiguration::class)->findOneBy([], ['id' => 'DESC']);
+
+        if (null === $apiConfiguration) {
+            $apiConfiguration = new ApiConfiguration();
+            $this->manager->persist($apiConfiguration);
+        }
+
+        $apiConfiguration->setBaseUrl('localhost:8987');
+        $apiConfiguration->setApiClientId('test');
+        $apiConfiguration->setApiClientSecret('test');
         $apiConfiguration->setPaginationSize(100);
         $apiConfiguration->setIsEnterprise(true);
-        $apiConfiguration->setUsername('');
-        $apiConfiguration->setPassword('');
-        $this->manager->persist($apiConfiguration);
+        $apiConfiguration->setUsername('test');
+        $apiConfiguration->setPassword('test');
+
         $this->manager->flush();
     }
 
@@ -188,12 +194,17 @@ abstract class AbstractTaskTest extends ApiTestCase
 
     private function createProductFiltersConfiguration(): void
     {
-        $productFilters = new ProductFiltersRules();
+        $productFilters = $this->manager->getRepository(ProductFiltersRules::class)->findOneBy([], ['id' => 'DESC']);
+
+        if (null === $productFilters) {
+            $productFilters = new ProductFiltersRules();
+            $this->manager->persist($productFilters);
+        }
+
         $productFilters->setMode(ProductFilterRuleAdvancedType::MODE)
             ->setAdvancedFilter('')
             ->setCompletenessValue(0)
         ;
-        $this->manager->persist($productFilters);
     }
 
     protected function importAttributes(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no
| Fixed issue | 

<!--
- Replace this comment by a description of what your PR is solving.
-->

IMHO we shouldn't call DB in `__construct()`.
An exception can be thrown during cache:clear for example;

    SQLSTATE[42S02]: Base table or view not found: 1146 Table 'test.akeneo_api_configuration' doesn't exist 
