### PR TITLE
Use last configuration en DB

### DIFF
--- a/ruleset/phpstan.neon
+++ b/ruleset/phpstan.neon
@@ -24,3 +24,4 @@ parameters:
     ignoreErrors:
         - '#Cannot call method [a-zA-Z0-9]+\(\) on Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface\|null.#'
         - '#Call to an undefined method League\\Pipeline\\PipelineInterface\:\:process\(\).#'
+        - '#Method Doctrine\\Persistence\\ObjectRepository<mixed>\:\:findOneBy\(\) invoked with 2 parameters, 1 required.#'

--- a/src/Checker/IsEnterpriseChecker.php
+++ b/src/Checker/IsEnterpriseChecker.php
@@ -21,7 +21,7 @@ final class IsEnterpriseChecker implements IsEnterpriseCheckerInterface
     public function isEnterprise(): bool
     {
         /** @var ApiConfiguration|null $apiConfiguration */
-        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([]);
+        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([], ['id' => 'DESC']);
 
         if (!$apiConfiguration instanceof ApiConfiguration) {
             throw new ApiNotConfiguredException();

--- a/src/Client/ClientFactory.php
+++ b/src/Client/ClientFactory.php
@@ -22,7 +22,7 @@ final class ClientFactory implements ClientFactoryInterface
     public function createFromApiCredentials(): AkeneoPimEnterpriseClientInterface
     {
         /** @var ApiConfiguration|null $apiConfiguration */
-        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([]);
+        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([], ['id' => 'DESC']);
 
         if (!$apiConfiguration instanceof ApiConfiguration) {
             throw new \Exception('The API is not configured in the admin section.');

--- a/src/Controller/ApiConfigurationController.php
+++ b/src/Controller/ApiConfigurationController.php
@@ -46,7 +46,7 @@ final class ApiConfigurationController extends AbstractController
     public function __invoke(Request $request): Response
     {
         /** @var ApiConfiguration|null $apiConfiguration */
-        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([]);
+        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([], ['id' => 'DESC']);
 
         if (!$apiConfiguration instanceof ApiConfiguration) {
             $apiConfiguration = new ApiConfiguration();

--- a/src/Controller/AttributesController.php
+++ b/src/Controller/AttributesController.php
@@ -54,7 +54,7 @@ final class AttributesController extends AbstractController
 
     public function __invoke(Request $request): Response
     {
-        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([]);
+        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([], ['id' => 'DESC']);
         if (!$apiConfiguration instanceof ApiConfiguration) {
             $this->flashBag->add('error', $this->translator->trans('sylius.ui.admin.akeneo.not_configured_yet'));
 

--- a/src/Controller/CategoriesController.php
+++ b/src/Controller/CategoriesController.php
@@ -44,7 +44,7 @@ final class CategoriesController extends AbstractController
 
     public function __invoke(Request $request): Response
     {
-        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([]);
+        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([], ['id' => 'DESC']);
         if (!$apiConfiguration instanceof ApiConfiguration) {
             $this->flashBag->add('error', $this->translator->trans('sylius.ui.admin.akeneo.not_configured_yet'));
 

--- a/src/Controller/ProductFilterRulesController.php
+++ b/src/Controller/ProductFilterRulesController.php
@@ -46,7 +46,7 @@ final class ProductFilterRulesController extends AbstractController
 
     public function __invoke(Request $request): Response
     {
-        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([]);
+        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([], ['id' => 'DESC']);
         if (!$apiConfiguration instanceof ApiConfiguration) {
             $this->flashBag->add('error', $this->translator->trans('sylius.ui.admin.akeneo.not_configured_yet'));
 

--- a/src/Controller/ProductsController.php
+++ b/src/Controller/ProductsController.php
@@ -44,7 +44,7 @@ final class ProductsController extends AbstractController
 
     public function __invoke(Request $request): Response
     {
-        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([]);
+        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([], ['id' => 'DESC']);
         if (!$apiConfiguration instanceof ApiConfiguration) {
             $this->flashBag->add('error', $this->translator->trans('sylius.ui.admin.akeneo.not_configured_yet'));
 
@@ -52,7 +52,7 @@ final class ProductsController extends AbstractController
         }
 
         /** @var ProductConfiguration $productConfiguration */
-        $productConfiguration = $this->productConfigurationRepository->findOneBy([]) ?? new ProductConfiguration();
+        $productConfiguration = $this->productConfigurationRepository->findOneBy([], ['id' => 'DESC']) ?? new ProductConfiguration();
 
         $form = $this->createForm(ProductConfigurationType::class, $productConfiguration);
         $form->handleRequest($request);

--- a/src/Filter/ProductFilter.php
+++ b/src/Filter/ProductFilter.php
@@ -51,7 +51,7 @@ final class ProductFilter implements ProductFilterInterface
     public function getProductModelFilters(): array
     {
         /** @var ProductFiltersRules $productFilterRules */
-        $productFilterRules = $this->productFiltersRulesRepository->findOneBy([]);
+        $productFilterRules = $this->productFiltersRulesRepository->findOneBy([], ['id' => 'DESC']);
         if (!$productFilterRules instanceof ProductFiltersRules) {
             return [];
         }
@@ -83,7 +83,7 @@ final class ProductFilter implements ProductFilterInterface
     public function getProductFilters(): array
     {
         /** @var ProductFiltersRules $productFilterRules */
-        $productFilterRules = $this->productFiltersRulesRepository->findOneBy([]);
+        $productFilterRules = $this->productFiltersRulesRepository->findOneBy([], ['id' => 'DESC']);
         if (!$productFilterRules instanceof ProductFiltersRules) {
             return [];
         }

--- a/src/Processor/AbstractImageProcessor.php
+++ b/src/Processor/AbstractImageProcessor.php
@@ -58,7 +58,7 @@ abstract class AbstractImageProcessor
             return $this->productConfiguration;
         }
 
-        $productConfiguration = $this->productConfigurationRepository->findOneBy([]);
+        $productConfiguration = $this->productConfigurationRepository->findOneBy([], ['id' => 'DESC']);
 
         if ($productConfiguration instanceof ProductConfiguration) {
             $this->productConfiguration = $productConfiguration;

--- a/src/Processor/Product/CompleteRequirementProcessor.php
+++ b/src/Processor/Product/CompleteRequirementProcessor.php
@@ -100,7 +100,7 @@ final class CompleteRequirementProcessor implements CompleteRequirementProcessor
             $productTranslation = $this->setProductTranslation($product, $usedLocalesOnBothPlatform, $productName);
 
             /** @var ProductConfiguration $configuration */
-            $configuration = $this->productConfigurationRepository->findOneBy([]);
+            $configuration = $this->productConfigurationRepository->findOneBy([], ['id' => 'DESC']);
             if (null !== $product->getId() &&
                 null !== $configuration &&
                 null !== $productTranslation->getSlug() &&

--- a/src/Processor/Product/ProductChannelEnablerProcessor.php
+++ b/src/Processor/Product/ProductChannelEnablerProcessor.php
@@ -71,7 +71,7 @@ final class ProductChannelEnablerProcessor implements ProductChannelEnablerProce
 
     private function getEnabledChannelsAttributeData(ProductInterface $product, array $resource): array
     {
-        $productConfiguration = $this->productConfigurationRepository->findOneBy([]);
+        $productConfiguration = $this->productConfigurationRepository->findOneBy([], ['id' => 'DESC']);
 
         if (!$productConfiguration instanceof ProductConfiguration) {
             throw new NoProductConfigurationException('Product Configuration is not configured in BO.');

--- a/src/Provider/ConfigurationProvider.php
+++ b/src/Provider/ConfigurationProvider.php
@@ -25,7 +25,7 @@ final class ConfigurationProvider
             return $this->configuration;
         }
 
-        $this->configuration = $this->apiConfigurationRepository->findOneBy([]);
+        $this->configuration = $this->apiConfigurationRepository->findOneBy([], ['id' => 'DESC']);
 
         if (!$this->configuration instanceof ApiConfiguration) {
             throw new Exception('The API is not configured in the admin section.');

--- a/src/Provider/ExcludedAttributesProvider.php
+++ b/src/Provider/ExcludedAttributesProvider.php
@@ -21,7 +21,7 @@ final class ExcludedAttributesProvider implements ExcludedAttributesProviderInte
     {
         $excludedAttributeCodes = [];
         /** @var \Synolia\SyliusAkeneoPlugin\Entity\ProductConfiguration|null $productConfiguration */
-        $productConfiguration = $this->productConfigurationRepository->findOneBy([]);
+        $productConfiguration = $this->productConfigurationRepository->findOneBy([], ['id' => 'DESC']);
 
         if (!$productConfiguration instanceof ProductConfiguration) {
             return [];

--- a/src/Provider/ProductFilterRulesProvider.php
+++ b/src/Provider/ProductFilterRulesProvider.php
@@ -25,7 +25,7 @@ final class ProductFilterRulesProvider implements ProductFilterRulesProviderInte
             return $this->productFiltersRules;
         }
 
-        $this->productFiltersRules = $this->productFiltersRulesRepository->findOneBy([]);
+        $this->productFiltersRules = $this->productFiltersRulesRepository->findOneBy([], ['id' => 'DESC']);
 
         if (!$this->productFiltersRules instanceof ProductFiltersRules) {
             throw new NoProductFiltersConfigurationException('Product filters must be configured before importing product attributes.');

--- a/src/Repository/CategoryConfigurationRepository.php
+++ b/src/Repository/CategoryConfigurationRepository.php
@@ -11,7 +11,7 @@ final class CategoryConfigurationRepository extends EntityRepository
 {
     public function getCategoriesConfiguration(): ?CategoryConfiguration
     {
-        $categoriesConfiguration = $this->findOneBy([]);
+        $categoriesConfiguration = $this->findOneBy([], ['id' => 'DESC']);
 
         if (!$categoriesConfiguration instanceof CategoryConfiguration) {
             return null;

--- a/src/Task/AbstractProcessTask.php
+++ b/src/Task/AbstractProcessTask.php
@@ -144,7 +144,7 @@ abstract class AbstractProcessTask implements AkeneoTaskInterface
         $this->logger->notice(Messages::createOrUpdate($this->type));
 
         /** @var ApiConfiguration|null $apiConfiguration */
-        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([]);
+        $apiConfiguration = $this->apiConfigurationRepository->findOneBy([], ['id' => 'DESC']);
 
         if (!$apiConfiguration instanceof ApiConfiguration) {
             throw new ApiNotConfiguredException();

--- a/src/Task/Product/AbstractCreateProductEntities.php
+++ b/src/Task/Product/AbstractCreateProductEntities.php
@@ -150,7 +150,7 @@ abstract class AbstractCreateProductEntities
     private function getPriceAttributeData(array $attributes): array
     {
         /** @var \Synolia\SyliusAkeneoPlugin\Entity\ProductConfiguration|null $productConfiguration */
-        $productConfiguration = $this->productConfigurationRepository->findOneBy([]);
+        $productConfiguration = $this->productConfigurationRepository->findOneBy([], ['id' => 'DESC']);
 
         if (!$productConfiguration instanceof ProductConfiguration) {
             throw new NoProductConfigurationException('Product Configuration is not configured in BO.');

--- a/src/Task/Product/ConfigurableProductsTask.php
+++ b/src/Task/Product/ConfigurableProductsTask.php
@@ -121,7 +121,7 @@ final class ConfigurableProductsTask extends AbstractCreateProductEntities
     public function __invoke(PipelinePayloadInterface $payload, array $resource): void
     {
         /** @var ProductFiltersRules $filters */
-        $filters = $this->productFiltersRulesRepository->findOneBy([]);
+        $filters = $this->productFiltersRulesRepository->findOneBy([], ['id' => 'DESC']);
         if (!$filters instanceof ProductFiltersRules) {
             throw new NoProductFiltersConfigurationException('Product filters must be configured before importing product attributes.');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no
| Fixed issue | #... <!-- #-prefixed issue number(s), if any -->

We can have multiples configuration by using fixtures, so i forced to take the last configuration stored in Database.
