### PR TITLE
[FIX] Avoid eternal taxons on products

### DIFF
--- a/src/Processor/Product/TaxonsProcessor.php
+++ b/src/Processor/Product/TaxonsProcessor.php
@@ -28,6 +28,7 @@ final class TaxonsProcessor implements TaxonsProcessorInterface
 
     public function process(ProductInterface $product, array $resource): void
     {
+        $product->getProductTaxons()->clear();
         $taxonCodes = array_unique($resource['categories']);
 
         foreach ($taxonCodes as $taxonCode) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no

Dissociate old taxons from the product before importing them again to avoid eternal taxons.