### PR TITLE
[Sylius 2.x] Added post flush event for product

### DIFF
--- a/src/Event/Product/PostFlushEvent.php
+++ b/src/Event/Product/PostFlushEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Synolia\SyliusAkeneoPlugin\Event\Product;
+
+use Sylius\Component\Core\Model\ProductInterface;
+use Synolia\SyliusAkeneoPlugin\Event\AbstractResourceEvent;
+
+class PostFlushEvent extends AbstractResourceEvent
+{
+    public function __construct(array $resource, private ProductInterface $product)
+    {
+        parent::__construct($resource);
+    }
+
+    public function getProduct(): ProductInterface
+    {
+        return $this->product;
+    }
+}

--- a/src/Processor/Resource/Product/ProductModelResourceProcessor.php
+++ b/src/Processor/Resource/Product/ProductModelResourceProcessor.php
@@ -16,6 +16,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Synolia\SyliusAkeneoPlugin\Checker\Product\IsProductProcessableCheckerInterface;
 use Synolia\SyliusAkeneoPlugin\Event\Product\AfterProcessingProductEvent;
 use Synolia\SyliusAkeneoPlugin\Event\Product\BeforeProcessingProductEvent;
+use Synolia\SyliusAkeneoPlugin\Event\Product\PostFlushEvent;
 use Synolia\SyliusAkeneoPlugin\Processor\Product\ProductProcessorChainInterface;
 use Synolia\SyliusAkeneoPlugin\Processor\ProductGroup\ProductGroupProcessor;
 use Synolia\SyliusAkeneoPlugin\Processor\Resource\AkeneoResourceProcessorInterface;
@@ -69,6 +70,7 @@ class ProductModelResourceProcessor implements AkeneoResourceProcessorInterface
 
             $this->dispatcher->dispatch(new AfterProcessingProductEvent($resource, $product));
             $this->entityManager->flush();
+            $this->dispatcher->dispatch(new PostFlushEvent($resource, $product));
         } catch (ORMInvalidArgumentException $ormInvalidArgumentException) {
             ++$this->retryCount;
             usleep($this->retryWaitTime);

--- a/src/Processor/Resource/ProductVariant/SimpleProductVariantResourceProcessor.php
+++ b/src/Processor/Resource/ProductVariant/SimpleProductVariantResourceProcessor.php
@@ -16,6 +16,7 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Synolia\SyliusAkeneoPlugin\Event\Product\AfterProcessingProductEvent;
 use Synolia\SyliusAkeneoPlugin\Event\Product\BeforeProcessingProductEvent;
+use Synolia\SyliusAkeneoPlugin\Event\Product\PostFlushEvent;
 use Synolia\SyliusAkeneoPlugin\Event\ProductVariant\AfterProcessingProductVariantEvent;
 use Synolia\SyliusAkeneoPlugin\Event\ProductVariant\BeforeProcessingProductVariantEvent;
 use Synolia\SyliusAkeneoPlugin\Processor\Product\ProductProcessorChainInterface;
@@ -91,8 +92,9 @@ class SimpleProductVariantResourceProcessor implements AkeneoResourceProcessorIn
 
             $product = $this->getOrCreateEntity($resource);
             $this->productProcessorChain->chain($product, $resource);
-
             $this->dispatcher->dispatch(new AfterProcessingProductEvent($resource, $product));
+            $this->entityManager->flush();
+            $this->dispatcher->dispatch(new PostFlushEvent($resource, $product));
 
             $this->dispatcher->dispatch(new BeforeProcessingProductVariantEvent($resource, $product));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?   | no
| Fixed issue | #... <!-- #-prefixed issue number(s), if any -->

Same as https://github.com/synolia/SyliusAkeneoPlugin/pull/207, but for Sylius 2.x
Allow to do some thing with a product after the flush

Credits to @TheGrimmChester :clap: 